### PR TITLE
DallasTemperature library removed; DSTherm support

### DIFF
--- a/library.json
+++ b/library.json
@@ -21,13 +21,8 @@
     "dependencies": [
         {
             "name": "OneWireNg",
-            "owner": "pstolarz",
-            "version": "^0.10.0"
+            "version": "https://github.com/pstolarz/OneWireNg"
         },
-        {
-            "name": "DallasTemperature",
-            "version": "https://github.com/pstolarz/Arduino-Temperature-Control-Library"
-        },      
         {
             "name": "SensESP",
             "owner": "SignalK",

--- a/platformio.ini
+++ b/platformio.ini
@@ -19,8 +19,7 @@ lib_ldf_mode = deep
 monitor_speed = 115200
 lib_deps =
    SignalK/SensESP@^2.0.0
-   pstolarz/OneWireNg@^0.10.0
-   https://github.com/pstolarz/Arduino-Temperature-Control-Library
+   https://github.com/pstolarz/OneWireNg
 
 [espressif32_base]
 ;this section has config items common to all ESP32 boards

--- a/src/sensesp_onewire/onewire_temperature.cpp
+++ b/src/sensesp_onewire/onewire_temperature.cpp
@@ -1,8 +1,11 @@
+#include <algorithm>
+
 #include "onewire_temperature.h"
 
-#include <DallasTemperature.h>
+#include "OneWireNg_CurrentPlatform.h"
+#include "utils/Placeholder.h"
 
-#include <algorithm>
+#define DEVICE_DISCONNECTED_C -127
 
 namespace sensesp {
 
@@ -28,35 +31,41 @@ bool string_to_owda(OWDevAddr* addr, const char* str) {
 
 DallasTemperatureSensors::DallasTemperatureSensors(int pin, String config_path)
     : Sensor(config_path) {
-  onewire_ = new OneWire(pin);
-  sensors_ = new DallasTemperature(onewire_);
-  sensors_->begin();
+  onewire_ = new OneWireNg_CurrentPlatform(
+    pin,
+    false // disable internal pull-up
+  );
+  DSTherm drv{*onewire_};
 
-  // DallasTemperature::getDeviceCount() doesn't work reliably with ESP32,
-  // so sensors are found using getAddress()
-
-  DeviceAddress addr;
-  OWDevAddr owda;
-  bool check_again = true;
-  uint8_t sensor_index = 0;
-  while (check_again) {
-    if (sensors_->getAddress(addr, sensor_index)) {
-      std::copy(std::begin(addr), std::end(addr), std::begin(owda));
-      known_addresses_.insert(owda);
-#ifndef DEBUG_DISABLED
-      char addrstr[24];
-      owda_to_string(addrstr, owda);
-      debugI("Found OneWire sensor %s", addrstr);
+#if (CONFIG_MAX_SRCH_FILTERS > 0)
+    static_assert(CONFIG_MAX_SRCH_FILTERS >= DSTherm::SUPPORTED_SLAVES_NUM,
+        "OneWireNg config: CONFIG_MAX_SRCH_FILTERS too small");
+#else
+# error "OneWireNg config: CONFIG_MAX_SRCH_FILTERS not defined"
 #endif
-      sensor_index++;
-    } else
-      check_again = false;
-  }
 
-  // all conversions will by async
-  sensors_->setWaitForConversion(false);
-  // always use maximum resolution
-  sensors_->setResolution(12);
+  // in the process of 1-wire bus scan
+  // filter out supported Dallas sensors
+  drv.filterSupportedSlaves();
+
+  OWDevAddr owda;
+
+  for (const auto& addr: *onewire_) {
+    std::copy(std::begin(addr), std::end(addr), std::begin(owda));
+    known_addresses_.insert(owda);
+#ifndef DEBUG_DISABLED
+    char addrstr[24];
+    owda_to_string(addrstr, owda);
+    debugI("Found OneWire sensor %s", addrstr);
+#endif
+    // Set common max. resolution (12-bits) for all handled sensors.
+    // The configuration will be valid until subsequent power cut-off.
+    drv.writeScratchpad(
+      addr,
+      0, 0, // disable alarm notifications
+      DSTherm::RES_12_BIT
+    );
+  }
 }
 
 bool DallasTemperatureSensors::register_address(const OWDevAddr& addr) {
@@ -131,13 +140,25 @@ void OneWireTemperature::start() {
 }
 
 void OneWireTemperature::update() {
-  dts_->sensors_->requestTemperaturesByAddress(address_.data());
+  dts_->get_dallas_driver().convertTemp(
+    *reinterpret_cast<OneWireNg::Id*>(address_.data()),
+    0 // don't wait for conversion
+  );
+
   // temp converstion can take up to 750 ms, so wait before reading
   ReactESP::app->onDelay(conversion_delay_, [this]() { this->read_value(); });
 }
 
 void OneWireTemperature::read_value() {
-  float tempC = dts_->sensors_->getTempC(address_.data());
+  Placeholder<DSTherm::Scratchpad> scrpd;
+  float tempC = DEVICE_DISCONNECTED_C;
+
+  if (dts_->get_dallas_driver().readScratchpad(
+    *reinterpret_cast<OneWireNg::Id*>(address_.data()),
+    &scrpd) == OneWireNg::EC_SUCCESS) {
+      tempC = ((DSTherm::Scratchpad&)scrpd).getTemp() / 1000.0;
+  }
+
   // we're on purpose ignoring the "conversion not ready" value (+85°C)
   // because the update method always waits for 750 ms before reading the value
   if (tempC == DEVICE_DISCONNECTED_C) {

--- a/src/sensesp_onewire/onewire_temperature.h
+++ b/src/sensesp_onewire/onewire_temperature.h
@@ -3,7 +3,8 @@
 
 #include <set>
 
-#include <DallasTemperature.h>
+#include "OneWireNg.h"
+#include "drivers/DSTherm.h"
 
 #include "sensesp/sensors/sensor.h"
 
@@ -32,9 +33,9 @@ class DallasTemperatureSensors : public Sensor {
   void start() override final {}
   bool register_address(const OWDevAddr& addr);
   bool get_next_address(OWDevAddr* addr);
-  DallasTemperature* sensors_;
+  DSTherm get_dallas_driver() { return DSTherm{*onewire_}; }
  private:
-  OneWire* onewire_;
+  OneWireNg* onewire_;
   std::set<OWDevAddr> known_addresses_;
   std::set<OWDevAddr> registered_addresses_;
 };
@@ -77,7 +78,7 @@ class OneWireTemperature : public FloatSensor {
 
  private:
   DallasTemperatureSensors* dts_;
-  uint conversion_delay_ = 750;
+  uint conversion_delay_ = DSTherm::MAX_CONV_TIME;
   uint read_delay_;
   bool found_ = true;
   OWDevAddr address_ = {};


### PR DESCRIPTION
As mentioned in #2 this PR provides Dallas thermometers support via OneWireNg's [`DSTherm`](https://github.com/pstolarz/OneWireNg/blob/master/src/drivers/DSTherm.h) driver. DallasTemperature library is removed. The code compiles fine but I didn't checks its runtime correctness.

Some notes:
* The change refers to `master` branch of OneWireNg lib since I needed to provide some [minor change](https://github.com/pstolarz/OneWireNg/commit/c195d5b812aa6855cb293f0d4524fef6fb392fd2) in `DSTherm` class which is not yet incorporated into any official release. Once released I will provide lib descriptor files of this library with proper update.
* I was unable to compile [the example](https://github.com/SensESP/OneWire/tree/main/examples/onewire_temperature) from this lib w/o fixing [SensESP](https://github.com/SignalK/SensESP) lib. While on [`v2-dev`](https://github.com/SignalK/SensESP/tree/v2-dev) branch I got compilation errors related to initialization lists usage in some constructors. After fixing some orders in those lists I finally was able to compile SensESP and the whole project. If you'd need to know more about this topic I may provide you with more details.
